### PR TITLE
Changed shuffle routing to balanced routing

### DIFF
--- a/benchmarks/flink-bench/src/main/java/fr/unice/yamb/flink/BenchmarkApplication.java
+++ b/benchmarks/flink-bench/src/main/java/fr/unice/yamb/flink/BenchmarkApplication.java
@@ -26,7 +26,7 @@ public class BenchmarkApplication {
                 else
                     throw new IllegalArgumentException("Field must be <int> or <String> instead it is <" + field.getClass().getName() + ">");
                 break;
-            case shuffle:
+            case balanced:
                 operator.rebalance();
                 break;
             case broadcast:

--- a/benchmarks/heron-bench/src/main/java/fr/unice/yamb/heron/BenchmarkApplication.java
+++ b/benchmarks/heron-bench/src/main/java/fr/unice/yamb/heron/BenchmarkApplication.java
@@ -21,7 +21,7 @@ public class BenchmarkApplication {
             case hash:
                 bolt.fieldsGrouping(parent, new Fields(field));
                 break;
-            case shuffle:
+            case balanced:
                 bolt.shuffleGrouping(parent);
             case broadcast:
                 bolt.allGrouping(parent);

--- a/benchmarks/storm-bench/src/main/java/fr/unice/yamb/storm/BenchmarkApplication.java
+++ b/benchmarks/storm-bench/src/main/java/fr/unice/yamb/storm/BenchmarkApplication.java
@@ -25,7 +25,7 @@ public class BenchmarkApplication {
             case hash:
                 bolt.partialKeyGrouping(parent, new Fields(field));
                 break;
-            case shuffle:
+            case balanced:
                 bolt.shuffleGrouping(parent);
                 break;
             case broadcast:

--- a/benchmarks/utils/src/main/java/fr/unice/yamb/utils/configuration/Config.java
+++ b/benchmarks/utils/src/main/java/fr/unice/yamb/utils/configuration/Config.java
@@ -20,7 +20,7 @@ public class Config {
     }
 
     public enum TrafficRouting{
-        shuffle, hash, broadcast
+        balanced, hash, broadcast
     }
 
     public enum LoadBalancing {
@@ -39,7 +39,7 @@ public class Config {
     public static final int DF_SCALABILITY_PARALLELISM = 10;
     public static final ParaBalancing DF_SCALABILITY_BALANCING = ParaBalancing.balanced;
     public static final ConnectionShape DF_CONNECTION_SHAPE = ConnectionShape.linear;
-    public static final TrafficRouting DF_TRAFFIC_ROUTING = TrafficRouting.shuffle;
+    public static final TrafficRouting DF_TRAFFIC_ROUTING = TrafficRouting.balanced;
     public static final boolean DF_MESSAGE_RELIABILITY = true;
     public static final int DF_WORKLOAD_PROCESSING = 300;
     public static final LoadBalancing DF_WORKLOAD_BALANCING = LoadBalancing.balanced;

--- a/conf/default.yml
+++ b/conf/default.yml
@@ -15,7 +15,7 @@ dataflow:
   connection: 
     shape: linear #[linear, diamond, star]
     ## Traffic Balancing
-    routing: shuffle # [shuffle, hash, broadcast]
+    routing: balanced # [balanced, hash, broadcast]
 
   ## Message Reliability
   reliable: true # Boolean, true to enable "acking-like" mechanism, false otherwise


### PR DESCRIPTION
#### PR Description

Changed configuration for traffic routing: renamed `shuffle` routing to `balanced` routing. 

#### Usage Example

For *users*: in `yamb.yml` use:
```yaml
connection:
    routing: balanced
```

For developers:
```java
import fr.unice.yamb.utils.configuration.Config;
Config.TrafficBalancing tb = Config.TrafficBalancing.balanced;
```

#### Closing issues

Closes #93
